### PR TITLE
Fix for latest Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
-
 name = "natural_sort"
 version = "0.0.1"
 authors = ["Ulysse Carion <ulysse@ulysse.io>"]
-
 description = "A library for natural sorting (aka human sorting)"
 homepage = "https://github.com/ucarion/natural-sort-rs"
 keywords = ["natural", "human", "sort"]
 license = "MIT"
+
+[dependencies]
+regex = "*"
+regex_macros = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,10 +31,9 @@
 //! Human-comparable strings can be created directly using
 //! `natural_sort::HumanString::from_str`.
 
-#![feature(phase)]
+#![feature(plugin)]
 
-#[phase(plugin)]
-extern crate regex_macros;
+#![plugin(regex_macros)]
 extern crate regex;
 
 pub use natural_sort::natural_sort;

--- a/src/natural_sort.rs
+++ b/src/natural_sort.rs
@@ -1,4 +1,8 @@
-#[deriving(Show, PartialEq, Eq)]
+use std::cmp::Ordering;
+use std::cmp::Ordering::*;
+use std::str::FromStr;
+
+#[derive(Show, PartialEq, Eq)]
 enum StringElem {
     Letters(String),
     Number(int)
@@ -6,7 +10,7 @@ enum StringElem {
 
 /// A `HumanString` is a sort of string-like object that can be compared in a
 /// human-friendly way.
-#[deriving(Show, PartialEq, Eq)]
+#[derive(Show, PartialEq, Eq)]
 pub struct HumanString {
     elems: Vec<StringElem>
 }
@@ -99,7 +103,7 @@ impl HumanString {
     fn process_number(regex_match: (uint, uint),
                       to_parse: String) -> (StringElem, String) {
         let (_, end_index) = regex_match;
-        let prefix_to_num: int = from_str(to_parse.slice_to(end_index))
+        let prefix_to_num: int = FromStr::from_str(to_parse.slice_to(end_index))
                                     .unwrap();
 
         let next_token = StringElem::Number(prefix_to_num);

--- a/src/natural_sort.rs
+++ b/src/natural_sort.rs
@@ -2,15 +2,15 @@ use std::cmp::Ordering;
 use std::cmp::Ordering::*;
 use std::str::FromStr;
 
-#[derive(Show, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 enum StringElem {
     Letters(String),
-    Number(int)
+    Number(i64)
 }
 
 /// A `HumanString` is a sort of string-like object that can be compared in a
 /// human-friendly way.
-#[derive(Show, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct HumanString {
     elems: Vec<StringElem>
 }
@@ -43,7 +43,7 @@ impl PartialOrd for HumanString {
         // First, create a list of Option<Ordering>s. If there's a type
         // mismatch, have the comparison resolve to `None`.
         let pairs = self.elems.iter().zip(other.elems.iter());
-        let mut compares = pairs.map(|pair|
+        let compares = pairs.map(|pair|
             match pair {
                 (&StringElem::Number(a), &StringElem::Number(b)) => {
                     a.partial_cmp(&b)
@@ -82,13 +82,13 @@ impl HumanString {
         let mut to_parse = String::from_str(string);
 
         while !to_parse.is_empty() {
-            let numbers_match = numbers_re.find(to_parse.as_slice());
+            let numbers_match = numbers_re.find(&to_parse[]);
 
             let (next_token, next_to_parse) = if numbers_match.is_some() {
                 HumanString::process_number(
                     numbers_match.unwrap(), to_parse)
             } else {
-                let letters_match = letters_re.find(to_parse.as_slice());
+                let letters_match = letters_re.find(&to_parse[]);
                 HumanString::process_letters(
                    letters_match.unwrap(), to_parse)
             };
@@ -100,25 +100,25 @@ impl HumanString {
         HumanString { elems: elems }
     }
 
-    fn process_number(regex_match: (uint, uint),
+    fn process_number(regex_match: (usize, usize),
                       to_parse: String) -> (StringElem, String) {
         let (_, end_index) = regex_match;
-        let prefix_to_num: int = FromStr::from_str(to_parse.slice_to(end_index))
+        let prefix_to_num: i64 = FromStr::from_str(&to_parse[..end_index])
                                     .unwrap();
 
         let next_token = StringElem::Number(prefix_to_num);
-        let to_parse_suffix = to_parse.slice_from(end_index).to_string();
+        let to_parse_suffix = to_parse[end_index..].to_string();
 
         (next_token, to_parse_suffix)
     }
 
-    fn process_letters(regex_match: (uint, uint),
+    fn process_letters(regex_match: (usize, usize),
                        to_parse: String) -> (StringElem, String) {
         let (_, end_index) = regex_match;
-        let prefix = to_parse.slice_to(end_index);
+        let prefix = &to_parse[..end_index];
 
         let next_token = StringElem::Letters(prefix.to_string());
-        let to_parse_suffix = to_parse.slice_from(end_index).to_string();
+        let to_parse_suffix = to_parse[end_index..].to_string();
 
         (next_token, to_parse_suffix)
     }


### PR DESCRIPTION
This fixes some compilation errors in newer versions of Rust, replaces deprecated integer types, and switches to the new slicing syntax.
