### PR TITLE
Switch to BigInt instead of i64, preventing crashes when dealing with strings containing very large numbers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ license = "MIT"
 [dependencies]
 regex = "*"
 regex_macros = "*"
+num = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@
 //! `natural_sort::HumanString::from_str`.
 
 #![feature(plugin, collections)]
+#![cfg(test)] #![feature(core)]
 
 #![plugin(regex_macros)]
 extern crate regex;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,8 @@
 #![plugin(regex_macros)]
 extern crate regex;
 
+extern crate num;
+
 pub use natural_sort::natural_sort;
 pub use natural_sort::HumanString;
 

--- a/src/natural_sort.rs
+++ b/src/natural_sort.rs
@@ -1,11 +1,12 @@
 use std::cmp::Ordering;
 use std::cmp::Ordering::*;
 use std::str::FromStr;
+use num::bigint::BigInt;
 
 #[derive(Debug, PartialEq, Eq)]
 enum StringElem {
     Letters(String),
-    Number(i64)
+    Number(BigInt)
 }
 
 /// A `HumanString` is a sort of string-like object that can be compared in a
@@ -45,7 +46,7 @@ impl PartialOrd for HumanString {
         let pairs = self.elems.iter().zip(other.elems.iter());
         let compares = pairs.map(|pair|
             match pair {
-                (&StringElem::Number(a), &StringElem::Number(b)) => {
+                (&StringElem::Number(ref a), &StringElem::Number(ref b)) => {
                     a.partial_cmp(&b)
                 },
 
@@ -103,7 +104,7 @@ impl HumanString {
     fn process_number(regex_match: (usize, usize),
                       to_parse: String) -> (StringElem, String) {
         let (_, end_index) = regex_match;
-        let prefix_to_num: i64 = FromStr::from_str(&to_parse[..end_index])
+        let prefix_to_num: BigInt = FromStr::from_str(&to_parse[..end_index])
                                     .unwrap();
 
         let next_token = StringElem::Number(prefix_to_num);

--- a/src/natural_sort.rs
+++ b/src/natural_sort.rs
@@ -3,6 +3,8 @@ use std::cmp::Ordering::*;
 use std::str::FromStr;
 use num::bigint::BigInt;
 
+#[cfg(test)] use std::num::FromPrimitive;
+
 #[derive(Debug, PartialEq, Eq)]
 enum StringElem {
     Letters(String),
@@ -149,7 +151,7 @@ pub fn natural_sort(strs: &mut [&str]) {
 #[test]
 fn test_makes_numseq() {
     let str1 = "123";
-    let hstr1 = HumanString { elems: vec![StringElem::Number(123)] };
+    let hstr1 = HumanString { elems: vec![StringElem::Number(BigInt::from_i32(123).unwrap())] };
     assert_eq!(HumanString::from_str(str1), hstr1);
 
     let str2 = "abc";
@@ -161,9 +163,9 @@ fn test_makes_numseq() {
     let str3 = "abc123xyz456";
     let hstr3 = HumanString {
         elems: vec![StringElem::Letters("abc".to_string()),
-                    StringElem::Number(123),
+                    StringElem::Number(BigInt::from_i32(123).unwrap()),
                     StringElem::Letters("xyz".to_string()),
-                    StringElem::Number(456)]
+                    StringElem::Number(BigInt::from_i32(456).unwrap())]
     };
     assert_eq!(HumanString::from_str(str3), hstr3);
 }


### PR DESCRIPTION
May introduce a slight performance penalty, but it shouldn't be a problem unless you're sorting millions of strings.
